### PR TITLE
Removing slash from the travis badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # qewd-ripple
 
-[![Build Status](https://travis-ci.org/RippleOSI/Qewd-Ripple.svg?branch=master)](https://travis-ci.org//RippleOSI/Qewd-Ripple)
+[![Build Status](https://travis-ci.org/RippleOSI/Qewd-Ripple.svg?branch=master)](https://travis-ci.org/RippleOSI/Qewd-Ripple)
 
 Email: <code.custodian@rippleosi.org>
 2016 Ripple Foundation Community Interest Company [http://rippleosi.org  ](http://rippleosi.org)


### PR DESCRIPTION
The following pull request removes the extra slash which is in the **Travis CI** badge link

@robtweed 